### PR TITLE
Add Explorer paper in Agent Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Many papers here are organized and identified using a visualization tool develop
 - [ACL 2024] [SeeClick: Harnessing GUI Grounding for Advanced Visual GUI Agents](https://arxiv.org/abs/2401.10935)
 
 ### Agent Data
+- [Explorer: Robust Collection of Interactable GUI Elements](https://arxiv.org/abs/2504.09352)
 - [AndroidLab: Training and Systematic Benchmarking of Android Autonomous Agents](https://arxiv.org/abs/2410.24024)
 - [Explorer: Scaling Exploration-driven Web Trajectory Synthesis for Multimodal Web Agents](https://arxiv.org/pdf/2502.11357)
 - [AgentTrek: Agent Trajectory Synthesis via Guiding Replay with Web Tutorials](https://arxiv.org/abs/2412.09605)


### PR DESCRIPTION
Add "Explorer: Robust Collection of Interactable GUI Elements" paper (https://arxiv.org/abs/2504.09352) to the Agent Data section. We propose open-sourced automatic gathering & labeling of GUI interaction training data and implement downstream agent training (GUI navigation, task replication across platforms).