### PR TITLE
Add Lumen — vision-first browser agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,5 @@ Many papers here are organized and identified using a visualization tool develop
 - [Bytebot](https://github.com/bytebot-ai/bytebot)
 - [UI-Act](https://github.com/TobiasNorlund/UI-Act)
 - [WebMarker](https://github.com/reidbarber/webmarker)
+- [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay. Screenshot → model → action loop over CDP, multi-provider support.
 - [Cua](https://github.com/trycua/cua)


### PR DESCRIPTION
Add [Lumen](https://github.com/omxyz/lumen) — vision-first browser agent with self-healing deterministic replay. Screenshot → model → action loop over CDP, multi-provider support.