### PR TITLE
Add LangGraph Computer Use Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Many papers here are organized and identified using a visualization tool develop
 - [Adversarial Attacks on Multimodal Agents](https://arxiv.org/abs/2406.12814)
 
 ## Projects
+- [LangGraph Computer Use Agent](https://github.com/Rajathbharadwaj/LangGraph-Computer-Use-Open-Source) - Open-source Computer Use Agent built with LangGraph. Docker + VNC + AI vision for controlling any computer.
 - [OpenInterpreter](https://github.com/OpenInterpreter/open-interpreter)
 - [OpenAdapt](https://github.com/OpenAdaptAI/OpenAdapt)
 - [OpenInterface](https://github.com/AmberSahdev/Open-Interface/)


### PR DESCRIPTION
## Description
Adds LangGraph Computer Use Agent to the Projects section.

## About
[LangGraph Computer Use Agent](https://github.com/Rajathbharadwaj/LangGraph-Computer-Use-Open-Source) is an open-source implementation of a Computer Use Agent.

### Features
- Built with LangGraph for agentic workflows
- Docker + VNC for isolated desktop control
- AI vision for screen understanding
- Free, open-source alternative

### Tech Stack
- Python / FastAPI
- LangGraph
- Docker / VNC
- OpenAI/Anthropic vision models

Licensed under MIT.