### PR TITLE
Add ClawBox to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Many papers here are organized and identified using a visualization tool develop
 - [Adversarial Attacks on Multimodal Agents](https://arxiv.org/abs/2406.12814)
 
 ## Projects
+- [ClawBox](https://github.com/coderkk1992/clawbox) - Run OpenClaw AI agent in a sandboxed Linux VM with native macOS UI. 5-minute setup, no CLI required.
 - [OpenInterpreter](https://github.com/OpenInterpreter/open-interpreter)
 - [OpenAdapt](https://github.com/OpenAdaptAI/OpenAdapt)
 - [OpenInterface](https://github.com/AmberSahdev/Open-Interface/)


### PR DESCRIPTION
Adding [ClawBox](https://github.com/coderkk1992/clawbox) to the Projects section.

ClawBox is a native macOS app that runs OpenClaw AI agent in a sandboxed Linux VM. The agent can browse the web, write code, and manage files - all isolated from your host system via Lima.

**Key features:**
- Native macOS UI (Tauri + React)
- AI runs in sandboxed VM
- Supports Claude and GPT
- 5-minute setup - no CLI or terminal required
- Drag & drop file sharing

Perfect fit for this list as it's specifically designed for running computer-use agents safely.