### PR TITLE
Add ClawBench paper to Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Many papers here are organized and identified using a visualization tool develop
 - [MobileAgentBench: An Efficient and User-Friendly Benchmark for Mobile LLM Agents](https://arxiv.org/abs/2406.08184)
 - [NeurIPS 2024] [Spider2-V: How Far Are Multimodal Agents From Automating Data Science and Engineering Workflows?](https://arxiv.org/abs/2407.10956)
 - [NeurIPS 2024] [OSWorld: Benchmarking Multimodal Agents for Open-Ended Tasks in Real Computer Environments](https://arxiv.org/abs/2404.07972)
+- [ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://huggingface.co/papers/2604.08523)
 
 ### Safety
 - [MobileSafetyBench: Evaluating Safety of Autonomous Agents in Mobile Device Control](https://arxiv.org/abs/2410.17520)


### PR DESCRIPTION
Adds ClawBench to the Evaluation / Benchmarks list.

ClawBench (arXiv 2026-04) evaluates browser agents on 153 everyday tasks across 144 live production websites in 15 categories. A submission-interception layer blocks only the final write request, so agents run full end-to-end flows on real sites (checkouts, bookings, forms) without creating real orders or side effects. Sits alongside WebArena, Mind2Web, OSWorld as a live-site peer.

- Paper: https://huggingface.co/papers/2604.08523
- Repo: https://github.com/reacher-z/ClawBench

**Affiliation disclosure:** I'm a maintainer of ClawBench. Kept the entry factual and matched surrounding formatting.